### PR TITLE
Fix webhook config

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ railway login
 railway init
 ```
 
-5. Добавьте переменные окружения:
+5. Добавьте переменную окружения:
 ```bash
 railway variables set TELEGRAM_TOKEN=your_telegram_token
-railway variables set WEBHOOK_URL=https://your-app.railway.app/webhook
 ```
+После генерации домена Railway автоматически задаст `RAILWAY_STATIC_URL`, из которой бот сформирует `WEBHOOK_URL`.
 
 6. Разверните приложение:
 ```bash

--- a/app/bot.py
+++ b/app/bot.py
@@ -3,8 +3,6 @@
 import logging
 import asyncio
 import os
-from typing import Optional
-import time
 
 from telegram.ext import (
     ApplicationBuilder,
@@ -105,14 +103,12 @@ async def run_polling():
 
 async def run_webhook():
     """Run the bot with webhook (for production)."""
-    # Всегда запускаем в режиме polling, если на Railway не настроен домен
-    if not os.environ.get("RAILWAY_STATIC_URL"):
-        logger.info("No RAILWAY_STATIC_URL environment variable, switching to polling mode")
+    if not config.WEBHOOK_URL:
+        logger.info("WEBHOOK_URL not set, switching to polling mode")
         await run_polling()
         return
-        
-    # Если есть RAILWAY_STATIC_URL, используем его для webhook
-    webhook_url = f"https://{os.environ.get('RAILWAY_STATIC_URL')}/webhook"
+
+    webhook_url = config.WEBHOOK_URL
     logger.info(f"Using webhook URL: {webhook_url}")
         
     application = await create_application()
@@ -130,12 +126,12 @@ async def run_webhook():
         logger.info(f"Webhook set to: {webhook_url}")
         
         # Запускаем webhook сервер
-        await application.updater.start_webhook(
-            listen="0.0.0.0",
-            port=int(os.environ.get("PORT", "8080")),
-            url_path="webhook",
-            drop_pending_updates=True,
-        )
+            await application.updater.start_webhook(
+                listen="0.0.0.0",
+                port=config.WEBHOOK_PORT,
+                url_path="webhook",
+                drop_pending_updates=True,
+            )
         
         # Проверяем, что webhook установлен
         webhook_info = await application.bot.get_webhook_info()

--- a/app/config.py
+++ b/app/config.py
@@ -25,7 +25,12 @@ class Config:
 
     # Webhook settings (for production)
     WEBHOOK_URL: Optional[str] = os.getenv("WEBHOOK_URL")
+    RAILWAY_STATIC_URL: Optional[str] = os.getenv("RAILWAY_STATIC_URL")
     WEBHOOK_PORT: int = int(os.getenv("PORT", "8443"))
+
+    # Construct webhook URL from Railway domain if needed
+    if not WEBHOOK_URL and RAILWAY_STATIC_URL:
+        WEBHOOK_URL = f"https://{RAILWAY_STATIC_URL}/webhook"
 
     # Default Pomodoro settings
     DEFAULT_WORK_MINUTES: int = 25

--- a/env.example
+++ b/env.example
@@ -5,8 +5,8 @@ TELEGRAM_TOKEN=your_telegram_token_here
 DATABASE_URL=sqlite:///pomodoro.sqlite3
 
 # Webhook settings (for production)
-# WEBHOOK_URL=https://your-app.railway.app/webhook
 # PORT=8443
+# RAILWAY_STATIC_URL is set automatically on Railway after you generate a domain
 
 # Development mode
 DEBUG=True 


### PR DESCRIPTION
## Summary
- generate webhook url from Railway static domain
- simplify webhook setup logic
- update documentation for Railway setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'telegram')*


------
https://chatgpt.com/codex/tasks/task_e_684868ba7fd88321a991fce2d3be5898